### PR TITLE
Consistently name XMS metrics and config

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -10,6 +10,8 @@ type AppConfiguration struct {
 
 	// XMS Configuration
 	XmsEnabled     bool
+	XmsUser        string `default:"admin"`
+	XmsPwd         string `default:"admin"`
 	XmsCountersURL string `default:"http://localhost:10080/resource/counters"`
 	XmsLicensesURL string `default:"http://localhost:10080/resource/licenses"`
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -5,15 +5,14 @@ var AppConfig = &AppConfiguration{}
 
 // AppConfiguration is used to define the TOML config structure
 type AppConfiguration struct {
-	Debug            bool
-	ListenAddress    string `default:":9055"`
-	JsonDebugEnabled bool
-	XmsDebugEnabled  bool
+	Debug         bool
+	ListenAddress string `default:":9055"`
+
 	// XMS Configuration
-	ResourceCountersEnabled bool
-	ResourceCountersURL     string `default:"http://localhost:10080/resource/counters"`
-	ResourceLicensesEnabled bool
-	ResourceLicensesURL     string `default:"http://localhost:10080/resource/licenses"`
+	XmsEnabled     bool
+	XmsCountersURL string `default:"http://localhost:10080/resource/counters"`
+	XmsLicensesURL string `default:"http://localhost:10080/resource/licenses"`
+
 	// C5 Configuration
 	SIPProxydEnabled        bool
 	SIPProxydURL            string `default:"http://127.0.0.1:9980/c5/proxy/commands?49&1&-v"`

--- a/main.go
+++ b/main.go
@@ -576,7 +576,7 @@ type Resource struct {
 
 // ---------------------------- Fetch For XMS REST API
 
-func fetchXmsMetrics(prefix, url string, wg *sync.WaitGroup) {
+func fetchXmsMetrics(prefix, url string, user string, pwd string, wg *sync.WaitGroup) {
 	logDebug("fetchXmsMetrics with prefix ", prefix, "from url", url)
 	defer wg.Done()
 	// Disable of certificate checks required for XMS in case HTTPS is used
@@ -705,8 +705,8 @@ func main() {
 		// --- XMS5 Metrics
 		if conf.XmsEnabled {
 			wg.Add(2)
-			go fetchXmsMetrics("xms_counter", conf.XmsCountersURL, &wg)
-			go fetchXmsMetrics("xms_license", conf.XmsLicensesURL, &wg)
+			go fetchXmsMetrics("xms_counter", conf.XmsCountersURL, conf.XmsUser, conf.XmsPwd, &wg)
+			go fetchXmsMetrics("xms_license", conf.XmsLicensesURL, conf.XmsUser, conf.XmsPwd, &wg)
 		}
 		// --- C5 Metrics
 		if conf.SIPProxydEnabled {
@@ -770,28 +770,28 @@ func logConfig() {
 		logDebug("  debug =", conf.Debug)
 		logDebug("  listenAddress =", conf.ListenAddress)
 		logDebug("  sipproxyd enabled =", conf.SIPProxydEnabled)
-		if conf.SIPProxydEnabled {
+	if conf.SIPProxydEnabled {
 			logDebug("  url:", conf.SIPProxydURL)
-		}
+	}
 		logDebug("  sipproxyd-trunk enabled:", conf.SIPProxydTrunksEnabled)
 		if conf.SIPProxydTrunksEnabled {
 			logDebug("    url stats:", conf.SIPProxydTrunkStatsURL)
 			logDebug("    url limit:", conf.SIPProxydTrunkLimitsURL)
 		}
 		logDebug("  acdqueued enabled:", conf.ACDQueuedEnabled)
-		if conf.ACDQueuedEnabled {
+	if conf.ACDQueuedEnabled {
 			logDebug("    url:", conf.ACDQueuedURL)
-		}
+	}
 		logDebug("  registard enabled:", conf.RegistrardEnabled)
-		if conf.RegistrardEnabled {
+	if conf.RegistrardEnabled {
 			logDebug("    url:", conf.RegistrardURL)
-		}
+	}
 		logDebug("  notification-server enabled:", conf.NotificationEnabled)
-		if conf.NotificationEnabled {
+	if conf.NotificationEnabled {
 			logDebug("    url:", conf.NotificationURL)
-		}
+	}
 		logDebug("  xms enabled:", conf.XmsEnabled)
-		if conf.XmsEnabled {
+	if conf.XmsEnabled {
 			logDebug("    url counter:", conf.XmsCountersURL)
 			logDebug("    url license:", conf.XmsLicensesURL)
 		}

--- a/main.go
+++ b/main.go
@@ -765,35 +765,30 @@ func logError(msg ...interface{}) {
 
 func logConfig() {
 	conf := config.AppConfig
-	if conf.Debug {
-		logDebug("Using configuration")
-		logDebug("  debug =", conf.Debug)
-		logDebug("  listenAddress =", conf.ListenAddress)
-		logDebug("  sipproxyd enabled =", conf.SIPProxydEnabled)
+	logDebug(fmt.Sprintf("Using configuration: %+v", conf))
 	if conf.SIPProxydEnabled {
-			logDebug("  url:", conf.SIPProxydURL)
+		logInfo("sipproxyd enabled with url", conf.SIPProxydURL)
 	}
-		logDebug("  sipproxyd-trunk enabled:", conf.SIPProxydTrunksEnabled)
-		if conf.SIPProxydTrunksEnabled {
-			logDebug("    url stats:", conf.SIPProxydTrunkStatsURL)
-			logDebug("    url limit:", conf.SIPProxydTrunkLimitsURL)
-		}
-		logDebug("  acdqueued enabled:", conf.ACDQueuedEnabled)
 	if conf.ACDQueuedEnabled {
-			logDebug("    url:", conf.ACDQueuedURL)
+		logInfo("acdqueued enabled with url", conf.ACDQueuedURL)
 	}
-		logDebug("  registard enabled:", conf.RegistrardEnabled)
 	if conf.RegistrardEnabled {
-			logDebug("    url:", conf.RegistrardURL)
+		logInfo("registrard enabled with url", conf.RegistrardURL)
 	}
-		logDebug("  notification-server enabled:", conf.NotificationEnabled)
+	if conf.SIPProxydTrunksEnabled {
+		logInfo("sipproxyd trunks enabled with:")
+		logInfo("- stats url:", conf.SIPProxydTrunkStatsURL)
+		logInfo("- limits url:", conf.SIPProxydTrunkLimitsURL)
+	}
 	if conf.NotificationEnabled {
-			logDebug("    url:", conf.NotificationURL)
+		logDebug("notification-server enabled with url:", conf.NotificationURL)
 	}
-		logDebug("  xms enabled:", conf.XmsEnabled)
+	if conf.CstaEnabled {
+		logDebug("cstagwd enabled with url:", conf.CstaURL)
+	}
 	if conf.XmsEnabled {
-			logDebug("    url counter:", conf.XmsCountersURL)
-			logDebug("    url license:", conf.XmsLicensesURL)
-		}
+		logInfo("xms enabled with user", conf.XmsUser)
+		logInfo("- counters url:", conf.XmsCountersURL)
+		logInfo("- licenses url:", conf.XmsLicensesURL)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -576,16 +576,15 @@ type Resource struct {
 
 // ---------------------------- Fetch For XMS REST API
 
-func fetchC5XmsMetrics(prefix, url string, wg *sync.WaitGroup) {
-	logDebug("fetchC5XmsMetrics: start")
+func fetchXmsMetrics(prefix, url string, wg *sync.WaitGroup) {
+	logDebug("fetchXmsMetrics with prefix ", prefix, "from url", url)
 	defer wg.Done()
-	// disable security check for a client
-	// Failed to connect Get "https://127.0.0.1:10443/resource/counters": x509: cannot validate certificate for xms because it doesn't contain any IP SANs
+	// Disable of certificate checks required for XMS in case HTTPS is used
+	// Failed to connect Get "https://127.0.0.1:10443/resource/counters":
+	//   x509: cannot validate certificate for XMS because it doesn't contain any IP SANs
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
-
-	//client := http.Client{Timeout: 2 * time.Second}
 	client := http.Client{Timeout: 2 * time.Second, Transport: tr}
 
 	req, err := http.NewRequest("GET", url, nil)
@@ -619,7 +618,7 @@ func fetchC5XmsMetrics(prefix, url string, wg *sync.WaitGroup) {
 	}
 
 	// fetch and set metrics
-	if prefix == "resourcecounters" {
+	if prefix == "xms_counter" {
 		processXmsResourceCountersMetrics(prefix, webService.Response.ResourceCounters)
 	} else {
 		processXmsResourceLicensesMetrics(prefix, webService.Response.ResourceLicenses)
@@ -641,14 +640,14 @@ func processXmsResourceCountersMetrics(prefix string, counters ResourceCounters)
 func processXmsResourceLicensesMetrics(prefix string, licenses ResourceLicenses) {
 
 	for _, item := range licenses.Resources {
-		//logDebug("fetchC5XmsMetrics: ", i, "     Id: ", item.Id) //xml
+		//logDebug("fetchXmsMetrics: ", i, "     Id: ", item.Id) //xml
 		prefixplus := prefix + `_` + item.Id + `_`
 		total, _ := strconv.ParseUint(item.Total, 0, 64)
 		used, _ := strconv.ParseUint(item.Used, 0, 64)
 		free, _ := strconv.ParseUint(item.Free, 0, 64)
 		percUsed, _ := strconv.ParseUint(item.PercUsed, 0, 64)
 		allocated, _ := strconv.ParseUint(item.Allocated, 0, 64)
-		//logDebug("fetchC5XmsMetrics: ", prefixplus+`total`,":", total) //xml
+		//logDebug("fetchXmsMetrics: ", prefixplus+`total`,":", total) //xml
 		setMetricValue(prefixplus+`total`, total)
 		setMetricValue(prefixplus+`used`, used)
 		setMetricValue(prefixplus+`free`, free)
@@ -684,8 +683,7 @@ func main() {
 		flag.Parse()
 	} else {
 		logInfo("No configuration file used. Enabling querying of all C5 and XMS processes.")
-		conf.ResourceCountersEnabled = true
-		conf.ResourceLicensesEnabled = true
+		conf.XmsEnabled = true
 		conf.SIPProxydEnabled = true
 		conf.ACDQueuedEnabled = true
 		conf.RegistrardEnabled = true
@@ -693,12 +691,11 @@ func main() {
 		conf.CstaEnabled = true
 	}
 
-	if !(conf.SIPProxydEnabled || conf.SIPProxydTrunksEnabled || conf.ACDQueuedEnabled || conf.RegistrardEnabled || conf.NotificationEnabled || conf.CstaEnabled || conf.ResourceCountersEnabled || conf.ResourceLicensesEnabled) {
+	if !(conf.SIPProxydEnabled || conf.SIPProxydTrunksEnabled || conf.ACDQueuedEnabled || conf.RegistrardEnabled || conf.NotificationEnabled || conf.CstaEnabled || conf.XmsEnabled) {
 		logError("No c5 or XMS processes enabled to query. Please enable at least on process in configuration.")
 		log.Fatal("Aborting.")
 	}
-	logJsonDebug()
-	logXmsDebug()
+	logConfig()
 
 	metricSet = metrics.NewSet()
 
@@ -706,13 +703,10 @@ func main() {
 	http.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 		var wg sync.WaitGroup
 		// --- XMS5 Metrics
-		if conf.ResourceCountersEnabled {
-			wg.Add(1)
-			go fetchC5XmsMetrics("resourcecounters", conf.ResourceCountersURL, &wg)
-		}
-		if conf.ResourceLicensesEnabled {
-			wg.Add(1)
-			go fetchC5XmsMetrics("resourcelicenses", conf.ResourceLicensesURL, &wg)
+		if conf.XmsEnabled {
+			wg.Add(2)
+			go fetchXmsMetrics("xms_counter", conf.XmsCountersURL, &wg)
+			go fetchXmsMetrics("xms_license", conf.XmsLicensesURL, &wg)
 		}
 		// --- C5 Metrics
 		if conf.SIPProxydEnabled {
@@ -769,33 +763,37 @@ func logError(msg ...interface{}) {
 	log.Print("[ERROR] ", fmt.Sprintln(msg...))
 }
 
-func logJsonDebug() {
+func logConfig() {
 	conf := config.AppConfig
-	if conf.JsonDebugEnabled {
-		logDebug("Using configuration:")
-		logDebug("- debug", conf.Debug, "listenAddress", conf.ListenAddress)
-		logDebug("- sipproxyd", conf.SIPProxydEnabled)
-		logDebug("  url:", conf.SIPProxydURL)
-		logDebug("- sipproxyd-trunk", conf.SIPProxydTrunksEnabled)
-		logDebug("  url stats:", conf.SIPProxydTrunkStatsURL)
-		logDebug("  url limit:", conf.SIPProxydTrunkLimitsURL)
-		logDebug("- acdqueued", conf.ACDQueuedEnabled)
-		logDebug("  url:", conf.ACDQueuedURL)
-		logDebug("- registard", conf.RegistrardEnabled)
-		logDebug("  url:", conf.RegistrardURL)
-		logDebug("- notification-server", conf.NotificationEnabled)
-		logDebug("  url:", conf.NotificationURL)
-	}
-}
-
-func logXmsDebug() {
-	conf := config.AppConfig
-	if conf.XmsDebugEnabled {
-		logDebug("Using configuration:")
-		logDebug("- debug", conf.Debug, "listenAddress", conf.ListenAddress)
-		logDebug("- resourcecounters", conf.ResourceCountersEnabled)
-		logDebug("  url:", conf.ResourceCountersURL)
-		logDebug("- resourcelicenses", conf.ResourceLicensesEnabled)
-		logDebug("  url:", conf.ResourceLicensesURL)
+	if conf.Debug {
+		logDebug("Using configuration")
+		logDebug("  debug =", conf.Debug)
+		logDebug("  listenAddress =", conf.ListenAddress)
+		logDebug("  sipproxyd enabled =", conf.SIPProxydEnabled)
+		if conf.SIPProxydEnabled {
+			logDebug("  url:", conf.SIPProxydURL)
+		}
+		logDebug("  sipproxyd-trunk enabled:", conf.SIPProxydTrunksEnabled)
+		if conf.SIPProxydTrunksEnabled {
+			logDebug("    url stats:", conf.SIPProxydTrunkStatsURL)
+			logDebug("    url limit:", conf.SIPProxydTrunkLimitsURL)
+		}
+		logDebug("  acdqueued enabled:", conf.ACDQueuedEnabled)
+		if conf.ACDQueuedEnabled {
+			logDebug("    url:", conf.ACDQueuedURL)
+		}
+		logDebug("  registard enabled:", conf.RegistrardEnabled)
+		if conf.RegistrardEnabled {
+			logDebug("    url:", conf.RegistrardURL)
+		}
+		logDebug("  notification-server enabled:", conf.NotificationEnabled)
+		if conf.NotificationEnabled {
+			logDebug("    url:", conf.NotificationURL)
+		}
+		logDebug("  xms enabled:", conf.XmsEnabled)
+		if conf.XmsEnabled {
+			logDebug("    url counter:", conf.XmsCountersURL)
+			logDebug("    url license:", conf.XmsLicensesURL)
+		}
 	}
 }

--- a/prometheus-c5-exporter.conf.example
+++ b/prometheus-c5-exporter.conf.example
@@ -27,5 +27,7 @@ notificationEnabled = true
 
 ### 3rd party XMS
 xmsEnabled = false
+#xmsUser = "admin"
+#xmsPwd = "admin"
 #xmsCountersURL = "http://localhost:10080/resource/counters"
 #xmsLicensesURL = "http://localhost:10080/resource/licenses"

--- a/prometheus-c5-exporter.conf.example
+++ b/prometheus-c5-exporter.conf.example
@@ -24,10 +24,8 @@ cstaEnabled = true
 ### Query notification-server process
 notificationEnabled = true
 # notificationURL = "http://127.0.0.1:9988/c5/proxy/commands?49&1&-v"
-#
 
 ### 3rd party XMS
-resourceCountersEnabled = false
-#resourceCountersURL = "http://localhost:10080/resource/counters"
-resourceLicensesEnabled = false
-#resourceLicensesURL = "http://localhost:10080/resource/licenses"
+xmsEnabled = false
+#xmsCountersURL = "http://localhost:10080/resource/counters"
+#xmsLicensesURL = "http://localhost:10080/resource/licenses"

--- a/resources/grafana/dashboard-xms-details.json
+++ b/resources/grafana/dashboard-xms-details.json
@@ -106,19 +106,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcecounters_received_sip_responses{instance=~\"$instance\"}",
+          "expr": "xms_counter_received_sip_responses{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Received SIP Responses ",
           "refId": "A"
         },
         {
-          "expr": "resourcecounters_sent_sip_invites{instance=~\"$instance\"}",
+          "expr": "xms_counter_sent_sip_invites{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Sent SIP Invites",
           "refId": "B"
         },
         {
-          "expr": "resourcecounters_sent_sip_responses{instance=~\"$instance\"}",
+          "expr": "xms_counter_sent_sip_responses{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Sent SIP Responses ",
           "refId": "C"
@@ -224,13 +224,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_basic_audio_used{instance=~\"$instance\"}",
+          "expr": "xms_license_basic_audio_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "D"
         },
         {
-          "expr": "resourcelicenses_basic_audio_free{instance=~\"$instance\"}",
+          "expr": "xms_license_basic_audio_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "E"
@@ -334,13 +334,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_lbr_audio_used{instance=~\"$instance\"}",
+          "expr": "xms_license_lbr_audio_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_lbr_audio_free{instance=~\"$instance\"}",
+          "expr": "xms_license_lbr_audio_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -444,13 +444,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_gsmamr_audio_used{instance=~\"$instance\"}",
+          "expr": "xms_license_gsmamr_audio_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_gsmamr_audio_free{instance=~\"$instance\"}",
+          "expr": "xms_license_gsmamr_audio_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -554,13 +554,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_hd_voice_used{instance=~\"$instance\"}",
+          "expr": "xms_license_hd_voice_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_hd_voice_free{instance=~\"$instance\"}",
+          "expr": "xms_license_hd_voice_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -664,13 +664,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_ipcc_used{instance=~\"$instance\"}",
+          "expr": "xms_license_ipcc_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_ipcc_free{instance=~\"$instance\"}",
+          "expr": "xms_license_ipcc_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -774,13 +774,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_advanced_video_used{instance=~\"$instance\"}",
+          "expr": "xms_license_advanced_video_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_advanced_video_free{instance=~\"$instance\"}",
+          "expr": "xms_license_advanced_video_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -884,13 +884,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_high_res_video_used{instance=~\"$instance\"}",
+          "expr": "xms_license_high_res_video_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_high_res_video_free{instance=~\"$instance\"}",
+          "expr": "xms_license_high_res_video_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -996,13 +996,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_mrcp_speech_server_used{instance=~\"$instance\"}",
+          "expr": "xms_license_mrcp_speech_server_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_mrcp_speech_server_free{instance=~\"$instance\"}",
+          "expr": "xms_license_mrcp_speech_server_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -1106,13 +1106,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_msrp_used{instance=~\"$instance\"}",
+          "expr": "xms_license_msrp_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_msrp_free{instance=~\"$instance\"}",
+          "expr": "xms_license_msrp_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -1216,13 +1216,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "resourcelicenses_fax_used{instance=~\"$instance\"}",
+          "expr": "xms_license_fax_used{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Used",
           "refId": "A"
         },
         {
-          "expr": "resourcelicenses_fax_free{instance=~\"$instance\"}",
+          "expr": "xms_license_fax_free{instance=~\"$instance\"}",
           "interval": "",
           "legendFormat": "Free",
           "refId": "B"
@@ -1280,15 +1280,11 @@
         "current": {
           "selected": true,
           "tags": [],
-          "text": [
-            "3rd-xms-3:9055"
-          ],
-          "value": [
-            "3rd-xms-3:9055"
-          ]
+          "text": ["3rd-xms-3:9055"],
+          "value": ["3rd-xms-3:9055"]
         },
         "datasource": null,
-        "definition": "label_values(resourcelicenses_basic_audio_used, instance)",
+        "definition": "label_values(xms_license_basic_audio_used, instance)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1298,7 +1294,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(resourcelicenses_basic_audio_used, instance)",
+          "query": "label_values(xms_license_basic_audio_used, instance)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Metrics are now named using the prefix `xms_license` and `xms_counter` (instead of `resources`).
Also config has been adjusted to consistently use the XMS prefix.
User/Pwd has also been externalized into the configuation.