### PR TITLE
Add state to processed process logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -550,6 +550,7 @@ func processBaseMetrics(prefix string, state c5StateResponse, attrs []MetricAttr
 	}
 	tmp := append(attrs, MetricAttribute{"version", version})
 	tmp = append(tmp, MetricAttribute{"starttime", startupTime})
+	tmp = append(tmp, MetricAttribute{"state", strings.TrimSpace(strings.Join([]string{state.ProxyState, state.QueueState, state.RegistrarState, state.NotificationServerState, state.CstaState}, " "))})
 	logInfo("Processed", prefix, tmp)
 	setMetricValue(buildMetricName(prefix, `info`, tmp), 1)
 


### PR DESCRIPTION
WIth this change the state of the processed process is also logged and helps in log analysis which process was active for a specific point in time.

```
2024/04/11 10:57:27 [INFO] Processed sipproxyd [{dc DefaultDC} {cmpGrp cg2} {version 7.7.1.3} {starttime 2024-04-07_04:01:18.261} {state active}]
2024/04/11 10:57:27 [INFO] Processed acdqueued [{dc DefaultDC} {cmpGrp cg2} {version 7.7.1.3} {starttime 2024-04-07_04:04:23.645} {state passive}]
```